### PR TITLE
Increase timestamp aligner memory efficiency

### DIFF
--- a/src/mne_videobrowser/timestamp_aligner.py
+++ b/src/mne_videobrowser/timestamp_aligner.py
@@ -381,7 +381,7 @@ class TimestampAligner:
         )
         self._log_mapping_errors(errors_ms)
 
-        mapping[valid_mask] = closest_target_indices.astype(np.int32)
+        mapping[valid_mask] = closest_target_indices.astype(np.int32, casting="safe")
 
         # Make sure that all the source indices were mapped.
         assert np.all(mapping != self._NOT_MAPPED), (


### PR DESCRIPTION
Made `TimestampAligner` more memory efficient by using internal numpy array instead of dictionary of objects.