### PR TITLE
Improve audio browser performance

### DIFF
--- a/src/mne_videobrowser/browsers/audio_browser.py
+++ b/src/mne_videobrowser/browsers/audio_browser.py
@@ -230,7 +230,6 @@ class AudioView(QWidget):
             sample_range=None,  # get all samples
         )
         n_points = len(times)
-        interleaved_times = np.empty(n_points * 2, dtype=times.dtype)
         interleaved_times = times.repeat(2)
 
         interleaved_audio = np.empty(n_points * 2, dtype=audio_min.dtype)


### PR DESCRIPTION
This PR makes it feasible to use audio browser with longer audio recordings. Changes:
- Audio browser stores again the whole (downsampled) audio envelope of the currently selected channel in memory, increases speed but costs memory.
- After the plot has been created, use `setData`method instead of clearing and recreating the plot.
- Use automatic downsampling provided by PyQtGraph to speed up rendering when zoomed out.
- Disable antialiasing and finite check.
- Use `clipToView` method to disable rendering of offscreen points.