### PR TITLE
Add tips about OpenGL and Linux Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,16 @@ dependency of `sounddevice` installed, install it. For example on Ubuntu/Debian:
    sudo apt install libportaudio2
    ```
 
+## Usage
+
 See usage examples in [GitHub](https://github.com/ttaiv/mne-videobrowser/tree/main/examples).
+
+> **Note:** The performance on some platforms might be largely affected by the parameter `use_opengl`
+> of MNE-Python's `raw.plot()` method. Experiment to find out the effect on you computer.
+>
+> **Extra note for Linux users:** If you encounter problems (for example not being able to drag the
+> video browser window) on Wayland, try telling Qt to use X11 instead by running
+> `export QT_QPA_PLATFORM=xcb` in your terminal.
 
 ## For developers
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -72,6 +72,23 @@ Using pip
 
       sudo apt install libportaudio2
 
+Usage
+-----
+
+See usage examples on `GitHub <https://github.com/ttaiv/mne-videobrowser/tree/main/examples>`_.
+
+.. admonition:: OpenGL affects performance
+
+   The performance on some platforms might be largely affected by the parameter
+   ``use_opengl`` of MNE-Python's ``raw.plot()`` method. Experiment to find out
+   the effect on your computer.
+
+.. admonition:: Wayland on Linux
+
+   If you encounter problems on Wayland (for example not being able to
+   drag the video browser window), try telling Qt to use X11 instead by running
+   ``export QT_QPA_PLATFORM=xcb`` in your terminal.
+
 
 Documentation Contents
 ----------------------

--- a/examples/audio_meg_sync.py
+++ b/examples/audio_meg_sync.py
@@ -60,6 +60,8 @@ def main() -> None:
         )
 
         # Start the synced raw and audio browsers.
+        # NOTE: Whether you should use OpenGL depends on your system and hardware.
+        # Try both True and False to see which option performs best on your setup.
         raw_browser = raw.plot(block=False, show=False, use_opengl=True)
         browse_raw_with_audio(raw_browser, raw, audio, aligner)
 

--- a/examples/multiple_meg_video_sync.py
+++ b/examples/multiple_meg_video_sync.py
@@ -118,6 +118,9 @@ def main() -> None:
     # Just to demonstrate multiple raw browsers, create another one.
     another_raw_browser = raw.plot(block=False, show=False, use_opengl=True)
 
+    # NOTE: Whether you should use OpenGL depends on your system and hardware.
+    # Try both True and False to see which option performs best on your setup.
+
     browse_raw_with_video(
         raw_browser,
         raw,

--- a/examples/two_video_audio_meg_sync.py
+++ b/examples/two_video_audio_meg_sync.py
@@ -86,6 +86,8 @@ def main() -> None:
         )
 
         # Start the browser.
+        # NOTE: Whether you should use OpenGL depends on your system and hardware.
+        # Try both True and False to see which option performs best on your setup.
         raw_browser = raw.plot(block=False, show=False, use_opengl=True)
         browse_raw_with_video_and_audio(
             raw_browser,

--- a/examples/two_video_meg_sync.py
+++ b/examples/two_video_meg_sync.py
@@ -71,6 +71,8 @@ def main() -> None:
         )
 
         # Start the browser.
+        # NOTE: Whether you should use OpenGL depends on your system and hardware.
+        # Try both True and False to see which option performs best on your setup.
         raw_browser = raw.plot(block=False, show=False, use_opengl=True)
         browse_raw_with_video(
             raw_browser,

--- a/examples/video_audio_meg_sync.py
+++ b/examples/video_audio_meg_sync.py
@@ -76,6 +76,8 @@ def main() -> None:
         )
 
         # Start the browser.
+        # NOTE: Whether you should use OpenGL depends on your system and hardware.
+        # Try both True and False to see which option performs best on your setup.
         raw_browser = raw.plot(block=False, show=False, use_opengl=True)
         browse_raw_with_video_and_audio(
             raw_browser, raw, [video], [video_aligner], audio, audio_aligner

--- a/examples/video_meg_sync.py
+++ b/examples/video_meg_sync.py
@@ -53,6 +53,8 @@ def main() -> None:
         )
 
         # Instantiate the browsers.
+        # NOTE: Whether you should use OpenGL depends on your system and hardware.
+        # Try both True and False to see which option performs best on your setup.
         raw_browser = raw.plot(block=False, show=False, use_opengl=True)
         browse_raw_with_video(
             raw_browser,

--- a/examples/video_sample_meg_sync.py
+++ b/examples/video_sample_meg_sync.py
@@ -105,6 +105,8 @@ def main() -> None:
     )
 
     # Launch the synced raw and video browsers.
+    # NOTE: Whether you should use OpenGL depends on your system and hardware.
+    # Try both True and False to see which option performs best on your setup.
     raw_browser = raw.plot(block=False, show=False, use_opengl=True)
     browse_raw_with_video(raw_browser, raw, [video], [aligner])
 

--- a/src/mne_videobrowser/browsers/video_browser.py
+++ b/src/mne_videobrowser/browsers/video_browser.py
@@ -480,7 +480,7 @@ class VideoView(QWidget):
         graphics_widget = pg.GraphicsView(parent=self)
         self._layout.addWidget(graphics_widget)
         # that has viewbox...
-        self._view_box = pg.ViewBox(lockAspect=True, invertY=True)
+        self._view_box = pg.ViewBox(lockAspect=True, invertY=True)  # pyright: ignore[reportCallIssue]
         graphics_widget.setCentralWidget(self._view_box)
         # that holds image item.
         self._image_view = pg.ImageItem()


### PR DESCRIPTION
- Added note about parameter `use_opengl` of `raw.plot()` affecting performance
  on some platforms to README, docs and examples.
- Added note about fixing Wayland issues by telling Qt to use X11 to README and docs. 
  